### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,9 @@
+# This file generated from a template file maintained in the ivoatex repository.
+# To create and install it into a project repository, do:
+#    make github-preview
+#    git commit
+#    git push
+#
 name: Check the IVOA document
 
 env:
@@ -11,29 +17,32 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
-    
+
     - name: Checkout the repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: true
-    
+
     - name: Setup dependencies
       run: |
         sudo apt update
-        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
-      
+        sudo apt install texlive-latex-base texlive-latex-recommended \
+                         texlive-latex-extra texlive-fonts-recommended \
+                         librsvg2-bin latexmk \
+                         pdftk xsltproc latexmk cm-super
+
     - name: Build the document
       run: make
-      
+
     - name: Check the output
       run: |
         test -f ${{ env.doc_name }}.pdf
         test -f ${{ env.doc_name }}.bbl
-        
-    - name: Keep the PDF artefact 
-      uses: actions/upload-artifact@v1
+
+    - name: Keep the PDF artefact
+      uses: actions/upload-artifact@v4
       with:
         name: PDF Preview
         path: ${{ env.doc_name }}.pdf

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,60 +1,73 @@
+# This file generated from a template file maintained in the ivoatex repository.
+# To create and install it into a project repository, do:
+#    make github-preview
+#    git commit
+#    git push
+#
 name: Update PDF Preview
 
 env:
-  doc_name: TAPRegExt
+  doc_name   : TAPRegExt
+  branch_name: ${{ github.head_ref || github.ref_name }}
+  tag_preview: auto-pdf-preview
 
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
-    
+
     runs-on: ubuntu-latest
-    
+
     steps:
-    
+
     - name: Checkout the repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: true
-    
+
     - name: Setup dependencies
       run: |
-        sudo apt update
-        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
-        sudo snap install pdftk
-    
+        sudo apt install texlive-latex-base texlive-latex-recommended \
+                         texlive-latex-extra texlive-fonts-recommended \
+                         librsvg2-bin latexmk \
+                         pdftk xsltproc latexmk cm-super
+
     - name: Build the document
       run: make ${{ env.doc_name }}-draft.pdf
-    
+
     - name: Check the output
       run: |
         test -f ${{ env.doc_name }}-draft.pdf
         test -f ${{ env.doc_name }}.bbl
-    
-    - name: Move the auto-pdf-preview tag
-      uses: weareyipyip/walking-tag-action@v1
-      with:
-        TAG_NAME: auto-pdf-preview
-        TAG_MESSAGE: |
-          Last commit taken into account for the automatically updated PDF preview of this IVOA document.
+
+    - name: Remove the former PDF preview (if any)
+      run: |
+        existingTag=$( gh release list --exclude-drafts --json 'isPrerelease,tagName' \
+                                       --jq '.[] | select(.isPrerelease == true and .tagName == "${{ env.tag_preview }}") | .tagName' \
+                                       | xargs -n 1 echo )
+        if [ -n "$existingTag" ];
+        then
+          gh release delete --cleanup-tag "$existingTag"
+        fi
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Update the PDF preview
-      uses: Xotl/cool-github-releases@v1
-      with:
-        mode: update
-        isPrerelease: true
-        tag_name: auto-pdf-preview
-        release_name: "Auto PDF Preview"
-        body_mrkdwn: |
-          This release aims to provide a PDF preview of the last commit applied on this repository.
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload the new PDF preview
+      run: |
+        RELEASE_NOTES="This release aims to provide a PDF preview of the last commit applied on this repository.
           It will be updated automatically after each merge of a PullRequest.
-          **DO NOT PUBLISH THIS PRE-RELEASE!**"
-          _Corresponding commit: ${{ github.sha }}_
-        assets: ${{ env.doc_name }}-draft.pdf
-        replace_assets: true
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+          **DO NOT PUBLISH THIS PRE-RELEASE!**
+          _Corresponding commit: ${{ github.sha }}_"
+
+        gh release create ${{ env.tag_preview }} \
+                          ${{ env.doc_name }}-draft.pdf \
+                          --prerelease \
+                          --target "${{ env.branch_name }}" \
+                          --title 'Auto PDF Preview' \
+                          --notes "$RELEASE_NOTES"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Makefile
+++ b/Makefile
@@ -28,30 +28,32 @@ VECTORFIGURES =
 
 
 # Additional files to distribute (e.g., CSS, schema files, examples...)
-AUX_FILES = $(SCHEMA_FILE)
+AUX_FILES = $(SCHEMA_FILE)  sample.xml
 
 -include ivoatex/Makefile
-
-sample.xml: samplegroom.sed Makefile
-	# this rule only works if there's a (proper) TAP service on
-	# http://localhost:8080/tap
-	curl -s http://dc.zah.uni-heidelberg.de/__system__/tap/run/tap/capabilities \
-		| xmlstarlet ed -d "//languageFeatures[@type='ivo://ivoa.net/std/TAPRegExt#features-udf']/feature[not(starts-with(form, 'ivo_hashlist_has'))]" \
-		  -d "//languageFeatures[@type='ivo://org.gavo.dc/std/exts#extra-adql-keywords']/feature[not(starts-with(form, 'MOC'))]" \
-		  -d "//outputFormat[not(@ivo-id or mime='text/csv')]" \
-		  -d "//capability[@standardID='ivo://ivoa.net/std/VOSI#availability']" \
-		  -d "//dataModel[@ivo-id='ivo://org.gavo.dc/std/glots#tables-1.0']" \
-		| xmlstarlet fo > $@.tmp
-	gavo admin xsdValidate $@.tmp
-	sed -f samplegroom.sed $@.tmp > $@
-	rm $@.tmp
-	
-
-install:
-	# local to Markus' setup
-	fixschema $(SCHEMA_FILE) > ~/gavo/trunk/schemata/TAPRegExt.xsd
 
 ivoatex/Makefile:
 	@echo "*** ivoatex submodule not found.  Initialising submodules."
 	@echo
 	git submodule update --init
+
+
+sample.xml: make-sample.sh
+	./make-sample.sh > sample.xml
+	
+install:
+	# local to Markus' setup
+	~/gavo/standards/fixschema $(SCHEMA_FILE) > ~/gavo/trunk/gavo/resources/schemata/TAPRegExt.xsd
+
+STILTS ?= stilts
+SCHEMA_FILE=TAPRegExt-v1.1.xsd
+
+# These tests need stilts >3.4 and xmlstarlet
+test:
+	@sh test-assertions.sh
+	@$(STILTS) xsdvalidate $(SCHEMA_FILE)
+	@$(STILTS) xsdvalidate \
+		schemaloc="http://www.ivoa.net/xml/TAPRegExt/v1.0=$(SCHEMA_FILE)" \
+		schemaloc="http://www.ivoa.net/xml/VOSICapabilities/v1.0=https://www.ivoa.net/xml/VOSICapabilities/v1.0" \
+		schemaloc="http://www.ivoa.net/xml/VODataService/v1.1=https://www.ivoa.net/xml/VODataService/v1.1" \
+		doc=sample.xml

--- a/TAPRegExt.tex
+++ b/TAPRegExt.tex
@@ -192,14 +192,12 @@ In TAPRegExt, a data model is identified by its IVOA identifier
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd DataModelType
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:DataModelType} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:DataModelType} Type Schema Documentation}
 
-\noindent{\small
-        An IVOA defined data model, identified by an IVORN
+\noindent{\small{}An IVOA defined data model, identified by an IVORN
         intended for machine consumption and a short label
-        intended for human comsumption.
-      \par}
+        intended for human comsumption.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:DataModelType} Type Schema Definition}
 
@@ -219,9 +217,7 @@ In TAPRegExt, a data model is identified by its IVOA identifier
 \item[ivo-id]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-            The IVOID of the data model.
-
+\item[Meaning] The IVOID of the data model.
 \item[Occurrence] required
 \end{description}
 
@@ -266,18 +262,14 @@ attributes of \xmlel{outputFormat} and \xmlel{uploadMethod}.
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd Language
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:Language} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:Language} Type Schema Documentation}
 
-\noindent{\small
-      A query language supported by the service.
-      \par}
+\noindent{\small{}A query language supported by the service.\par}
 
-\noindent{\small
-      Each language element can describe one or more versions
+\noindent{\small{}Each language element can describe one or more versions
       of a language.  Either name alone or name-version can be
-      used as values for the server's LANG parameter.
-      \par}
+      used as values for the server's LANG parameter.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:Language} Type Schema Definition}
 
@@ -301,43 +293,33 @@ attributes of \xmlel{outputFormat} and \xmlel{uploadMethod}.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{name}]
 \begin{description}
 \item[Type] a prefixless XML name
-\item[Meaning]
-          The name of the language without a version suffix.
-
+\item[Meaning] The name of the language without a version suffix.
 \item[Occurrence] required
 
 \end{description}
 \item[Element \xmlel{version}]
 \begin{description}
 \item[Type] a string with optional attributes
-\item[Meaning]
-            A version of the language supported by the server.
-
+\item[Meaning] A version of the language supported by the server.
 \item[Occurrence] required; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{description}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-          A short, human-readable description of the
+\item[Meaning] A short, human-readable description of the
           query language.
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{languageFeatures}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:LanguageFeatureList}
-\item[Meaning]
-            Optional features of the query language, grouped by
+\item[Meaning] Optional features of the query language, grouped by
             feature type.
-
 \item[Occurrence] optional; multiple occurrences allowed.
-\item[Comment]
-            This includes listing user defined functions, geometry support,
+\item[Comment] This includes listing user defined functions, geometry support,
             or similar concepts.
-
 
 \end{description}
 
@@ -352,21 +334,17 @@ attributes of \xmlel{outputFormat} and \xmlel{uploadMethod}.
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd Version
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:Version} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:Version} Type Schema Documentation}
 
-\noindent{\small
-      One version of the language supported by the service.
-      \par}
+\noindent{\small{}One version of the language supported by the service.\par}
 
-\noindent{\small
-      If the service supports more than one version of the
+\noindent{\small{}If the service supports more than one version of the
       language, include multiple version elements.
       It is recommended that you use a version numbering
       scheme like MAJOR.MINOR in such a way that sorting
       by ascending character codes will leave the most
-      recent version at the bottom of the list.
-      \par}
+      recent version at the bottom of the list.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:Version} Type Schema Definition}
 
@@ -386,17 +364,13 @@ attributes of \xmlel{outputFormat} and \xmlel{uploadMethod}.
 \item[ivo-id]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-            An optional IVOID of the language.
-
+\item[Meaning] An optional IVOID of the language.
 \item[Occurrence] optional
-\item[Comment]
-              To more formally define a language supported by a service,
+\item[Comment] To more formally define a language supported by a service,
               a resource record for the language can be created, either
               centrally on the Registry of Registries or by other registry operators.
               When such a record exists, the ivo-id attribute of language
               should point to it.
-
 \end{description}
 
 
@@ -489,18 +463,15 @@ Example:
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd LanguageFeatureList
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:LanguageFeatureList} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:LanguageFeatureList} Type Schema Documentation}
 
-\noindent{\small
-        An enumeration of non-standard or non-mandatory features of
-        a specific type implemented by the language.
-      \par}
+\noindent{\small{}An enumeration of non-standard or non-mandatory features of
+        a specific type implemented by the language.\par}
 
-\noindent{\small
-        A feature type is a language-dependent concept like
-        "user defined function", "geometry support", or possibly
-        "units supported".  A featureList gives all features of
+\noindent{\small{}A feature type is a language-dependent concept like
+        {"}user defined function{"}, {"}geometry support{"}, or possibly
+        {"}units supported{"}.  A featureList gives all features of
         a given type applicable for the service.  Multiple featureLists
         are possible.
 
@@ -509,8 +480,7 @@ Example:
         the value of which will typically be an IVOID.
         To see values defined in TAPRegExt,
         retrieve the ivo://ivoa.net/std/TAPRegExt
-        resource record and look for keys starting with "features-".
-      \par}
+        resource record and look for keys starting with {"}features-{"}.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:LanguageFeatureList} Type Schema Definition}
 
@@ -530,15 +500,11 @@ Example:
 \item[type]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-          The type of the features given here.
-
+\item[Meaning] The type of the features given here.
 \item[Occurrence] required
-\item[Comment]
-          This is in general an IVOID.  TAPRegExt itself gives
+\item[Comment] This is in general an IVOID.  TAPRegExt itself gives
           IVOIDs for defining user defined functions and geometry
           support.
-
 \end{description}
 
 
@@ -551,10 +517,8 @@ Example:
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{feature}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:LanguageFeature}
-\item[Meaning]
-            A language feature of the type given by the
+\item[Meaning] A language feature of the type given by the
             type attribute.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
@@ -570,13 +534,11 @@ Example:
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd LanguageFeature
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:LanguageFeature} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:LanguageFeature} Type Schema Documentation}
 
-\noindent{\small
-        A non-standard or non-mandatory feature implemented
-        by the language..
-      \par}
+\noindent{\small{}A non-standard or non-mandatory feature implemented
+        by the language..\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:LanguageFeature} Type Schema Definition}
 
@@ -594,22 +556,16 @@ Example:
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{form}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-            Formal notation for the language feature.
-
+\item[Meaning] Formal notation for the language feature.
 \item[Occurrence] required
-\item[Comment]
-            The syntax for the content of this element is defined by the
+\item[Comment] The syntax for the content of this element is defined by the
             type attribute of its parent language list.
-
 
 \end{description}
 \item[Element \xmlel{description}]
 \begin{description}
 \item[Type] string: \xmlel{xs:string}
-\item[Meaning]
-            Human-readable freeform documentation for the language feature.
-
+\item[Meaning] Human-readable freeform documentation for the language feature.
 \item[Occurrence] optional
 
 \end{description}
@@ -647,15 +603,12 @@ VOTables which are not interoperably distinguishable by their MIME types so far:
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd OutputFormat
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:OutputFormat} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:OutputFormat} Type Schema Documentation}
 
-\noindent{\small
-      An output format supported by the service.
-      \par}
+\noindent{\small{}An output format supported by the service.\par}
 
-\noindent{\small
-      All TAP services must support VOTable output, with media types as
+\noindent{\small{}All TAP services must support VOTable output, with media types as
       requested by the FORMAT parameter if applicable (cf.~section 2.7.1
       of the TAP standard).
 
@@ -664,8 +617,7 @@ VOTables which are not interoperably distinguishable by their MIME types so far:
       use a media type (or make one up using the x- syntax), although
       the concrete media syntax is not enforced by the schema.
 
-      For more detailed specification, an IVOID may be used.
-      \par}
+      For more detailed specification, an IVOID may be used.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:OutputFormat} Type Schema Definition}
 
@@ -676,6 +628,7 @@ VOTables which are not interoperably distinguishable by their MIME types so far:
     <xs:element name="alias" type="xs:token" minOccurs="0"
               maxOccurs="unbounded" />
   </xs:sequence>
+  <xs:attributeGroup ref="tr:mode-dependent" />
   <xs:attribute name="ivo-id" type="xs:anyURI" />
 </xs:complexType>
 \end{lstlisting}
@@ -686,19 +639,15 @@ VOTables which are not interoperably distinguishable by their MIME types so far:
 \item[ivo-id]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-        An optional IVOID of the output format.
-
+\item[Meaning] An optional IVOID of the output format.
 \item[Occurrence] optional
-\item[Comment]
-          When the media type does not uniquely define the
+\item[Comment] When the media type does not uniquely define the
           format (or a generic media type like application/octet-stream or
           text/plain is given), the IVOID can point to a key
           or StandardsRegExt document defining the format more
           precisely.  To see values defined in TAPRegExt,
           retrieve the ivo://ivoa.net/std/TAPRegExt
           resource record and look for keys starting with {"}output-{"}.
-
 \end{description}
 
 
@@ -711,24 +660,18 @@ VOTables which are not interoperably distinguishable by their MIME types so far:
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{mime}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-          The media type of this format.
-
+\item[Meaning] The media type of this format.
 \item[Occurrence] required
-\item[Comment]
-          The format of this string is specified by RFC 2046.
+\item[Comment] The format of this string is specified by RFC 2046.
           The service has to accept this string as a
           value of the FORMAT parameter.
-
 
 \end{description}
 \item[Element \xmlel{alias}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-          Other values of FORMAT ({"}shorthands{"}) that make the service return
+\item[Meaning] Other values of FORMAT ({"}shorthands{"}) that make the service return
           documents with the media type.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
@@ -793,24 +736,20 @@ would say:
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd UploadMethod
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:UploadMethod} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:UploadMethod} Type Schema Documentation}
 
-\noindent{\small
-      An upload method as defined by IVOA.
-      \par}
+\noindent{\small{}An upload method as defined by IVOA.\par}
 
-\noindent{\small
-      Upload methods are always identified by an IVOID.
+\noindent{\small{}Upload methods are always identified by an IVOID.
       Descriptions can be obtained by dereferencing this
       IVOID.  To see values defined in TAPRegExt,
       retrieve the ivo://ivoa.net/std/TAPRegExt
-      resource record and look for keys starting with "upload-".
+      resource record and look for keys starting with {"}upload-{"}.
 
       You can register custom upload methods, but you must use the
       standard IVOIDs for the upload methods defined in the TAP
-      specification.
-      \par}
+      specification.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:UploadMethod} Type Schema Definition}
 
@@ -830,9 +769,7 @@ would say:
 \item[ivo-id]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-            The IVOID of the upload method.
-
+\item[Meaning] The IVOID of the upload method.
 \item[Occurrence] optional
 \end{description}
 
@@ -897,12 +834,10 @@ All values in time-like limits are given in seconds.  Both
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd TimeLimits
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:TimeLimits} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:TimeLimits} Type Schema Documentation}
 
-\noindent{\small
-      Time-valued limits, all values given in seconds.
-      \par}
+\noindent{\small{}Time-valued limits, all values given in seconds.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:TimeLimits} Type Schema Definition}
 
@@ -921,18 +856,14 @@ All values in time-like limits are given in seconds.  Both
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{default}]
 \begin{description}
 \item[Type] integer
-\item[Meaning]
-          The value of this limit for newly-created jobs, given in seconds.
-
+\item[Meaning] The value of this limit for newly-created jobs, given in seconds.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{hard}]
 \begin{description}
 \item[Type] integer
-\item[Meaning]
-          The value this limit cannot be raised above, given in seconds.
-
+\item[Meaning] The value this limit cannot be raised above, given in seconds.
 \item[Occurrence] optional
 
 \end{description}
@@ -976,12 +907,10 @@ and \xmlel{tr:DataLimit} types:
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd DataLimits
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:DataLimits} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:DataLimits} Type Schema Documentation}
 
-\noindent{\small
-      Limits on data sizes, given in rows or bytes.
-      \par}
+\noindent{\small{}Limits on data sizes, given in rows or bytes.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:DataLimits} Type Schema Definition}
 
@@ -1001,18 +930,14 @@ and \xmlel{tr:DataLimit} types:
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{default}]
 \begin{description}
 \item[Type] an integer with optional attributes
-\item[Meaning]
-          The value of this limit for newly-created jobs.
-
+\item[Meaning] The value of this limit for newly-created jobs.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{hard}]
 \begin{description}
 \item[Type] an integer with optional attributes
-\item[Meaning]
-          The value this limit cannot be raised above.
-
+\item[Meaning] The value this limit cannot be raised above.
 \item[Occurrence] optional
 
 \end{description}
@@ -1028,12 +953,10 @@ and \xmlel{tr:DataLimit} types:
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd DataLimit
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:DataLimit} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:DataLimit} Type Schema Documentation}
 
-\noindent{\small
-      A limit on some data size, either in rows or in bytes.
-      \par}
+\noindent{\small{}A limit on some data size, either in rows or in bytes.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:DataLimit} Type Schema Definition}
 
@@ -1060,9 +983,7 @@ and \xmlel{tr:DataLimit} types:
 \item[unit]
 \begin{description}
 \item[Type] string with controlled vocabulary
-\item[Meaning]
-            The unit of the limit specified.
-
+\item[Meaning] The unit of the limit specified.
 \item[Occurrence] required
 
 \item[Allowed Values]\hfil
@@ -1115,20 +1036,16 @@ another interface element of type \xmlel{tr:DALIInterface}.
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd DALIInterface
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:DALIInterface} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:DALIInterface} Type Schema Documentation}
 
-\noindent{\small
-        An interface for a complex, multi-endpoint interfaces as
-        regulated by DALI.
-      \par}
+\noindent{\small{}An interface for a complex, multi-endpoint interfaces as
+        regulated by DALI.\par}
 
-\noindent{\small
-        In addition to the standard vr:Interface elements, DALIInterfaces
+\noindent{\small{}In addition to the standard vr:Interface elements, DALIInterfaces
         have endpoints, listed by name; that name doubles as a path segment
         to append to the interface's access URL, yielding the URI at
-        which the endpoint is operated.
-      \par}
+        which the endpoint is operated.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:DALIInterface} Type Schema Definition}
 
@@ -1150,9 +1067,7 @@ another interface element of type \xmlel{tr:DALIInterface}.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{endpoint}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:Endpoint}
-\item[Meaning]
-                An endpoint accessible through this interface.
-
+\item[Meaning] An endpoint accessible through this interface.
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
@@ -1176,19 +1091,15 @@ datalink?}.
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd Endpoint
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:Endpoint} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:Endpoint} Type Schema Documentation}
 
-\noindent{\small
-        An endpoint of a complex interface.
-      \par}
+\noindent{\small{}An endpoint of a complex interface.\par}
 
-\noindent{\small
-        An endpoint is characterised and addrssed by its name;
+\noindent{\small{}An endpoint is characterised and addressed by its name;
         they can further be defined through RDF triples.  This is a
         generic extension mechanism for endpoint-specific metadata,
-        primarily intended for custom, vendor-specific extensions.
-      \par}
+        primarily intended for custom, vendor-specific extensions.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:Endpoint} Type Schema Definition}
 
@@ -1207,24 +1118,18 @@ datalink?}.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{name}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-            The endpoint name, which is also the last component of the
+\item[Meaning] The endpoint name, which is also the last component of the
             path of its URI.
-
 \item[Occurrence] required
-\item[Comment]
-            Names without dashes are reserved for IVOA use and are expected to
+\item[Comment] Names without dashes are reserved for IVOA use and are expected to
             work the same way on all services.  Well-known examples for
             such endpoint names include sync, async, and tables.
-
 
 \end{description}
 \item[Element \xmlel{meta}]
 \begin{description}
 \item[Type] a string with optional attributes
-\item[Meaning]
-            Auxiliary information on this endpoint.
-
+\item[Meaning] Auxiliary information on this endpoint.
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
@@ -1255,13 +1160,11 @@ make statements consisting of a subject (\xmlel{about}), a predicate
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd MetaTriple
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:MetaTriple} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:MetaTriple} Type Schema Documentation}
 
-\noindent{\small
-        A container for an RDFa triple giving information related to
-        an endpoint.
-      \par}
+\noindent{\small{}A container for an RDFa triple giving information related to
+        an endpoint.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:MetaTriple} Type Schema Definition}
 
@@ -1283,39 +1186,27 @@ make statements consisting of a subject (\xmlel{about}), a predicate
 \item[about]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-              The subject of the statement.
-
+\item[Meaning] The subject of the statement.
 \item[Occurrence] optional
-\item[Comment]
-              If missing, the endpoint itself is assumed as the subject.
-
+\item[Comment] If missing, the endpoint itself is assumed as the subject.
 \end{description}
 \item[property]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-              The property of the statement.
-
+\item[Meaning] The property of the statement.
 \item[Occurrence] required
-\item[Comment]
-              This is a reference to an RDF resource.  IVOA standards may define
+\item[Comment] This is a reference to an RDF resource.  IVOA standards may define
               semantics for scheme-less URI; non-IVOA properties must use
               full URIs with at least scheme and authority; in this
               version, no vocab attributes are supported.
-
 \end{description}
 \item[resource]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-              The object of the statement.
-
+\item[Meaning] The object of the statement.
 \item[Occurrence] optional
-\item[Comment]
-              If missing, the text content of the element is used as the
+\item[Comment] If missing, the text content of the element is used as the
               object.
-
 \end{description}
 
 
@@ -1419,17 +1310,13 @@ be given for TAP 1.0 services.  Services having other capabilities
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd TableAccess
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:TableAccess} Type Schema Documentation}
+       \renewcommand*\descriptionlabel[1]{%
+       \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{tr:TableAccess} Type Schema Documentation}
 
-\noindent{\small
-      The capabilities of a TAP server.
-      \par}
+\noindent{\small{}The capabilities of a TAP server.\par}
 
-\noindent{\small
-      The capabilities attempt to define most issues that the
-      TAP standard leaves to the implementors ("may", "should").
-      \par}
+\noindent{\small{}The capabilities attempt to define most issues that the
+      TAP standard leaves to the implementors ({"}may{"}, {"}should{"}).\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{tr:TableAccess} Type Schema Definition}
 
@@ -1466,79 +1353,61 @@ be given for TAP 1.0 services.  Services having other capabilities
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{dataModel}]
 \begin{description}
 \item[Type] a string with optional attributes
-\item[Meaning]
-              Identifier of IVOA-approved data model supported by the
+\item[Meaning] Identifier of IVOA-approved data model supported by the
               service.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{language}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:Language}
-\item[Meaning]
-              Language supported by the service.
-
+\item[Meaning] Language supported by the service.
 \item[Occurrence] required; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{outputFormat}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:OutputFormat}
-\item[Meaning]
-                Output format supported by the service.
-
+\item[Meaning] Output format supported by the service.
 \item[Occurrence] required; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{uploadMethod}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:UploadMethod}
-\item[Meaning]
-                Upload method supported by the service.
-
+\item[Meaning] Upload method supported by the service.
 \item[Occurrence] optional; multiple occurrences allowed.
-\item[Comment]
-                The absence of upload methods indicates
+\item[Comment] The absence of upload methods indicates
                 that the service does not support uploads
                 at all.
-
 
 \end{description}
 \item[Element \xmlel{retentionPeriod}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:TimeLimits}
-\item[Meaning]
-              Limits on the time between job creation and
+\item[Meaning] Limits on the time between job creation and
               destruction time.
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{executionDuration}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:TimeLimits}
-\item[Meaning]
-              Limits on executionDuration.
-
+\item[Meaning] Limits on executionDuration.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{outputLimit}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:DataLimits}
-\item[Meaning]
-              Limits on the size of data returned.
-
+\item[Meaning] Limits on the size of data returned.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{uploadLimit}]
 \begin{description}
 \item[Type] composite: \xmlel{tr:DataLimits}
-\item[Meaning]
-              Limits on the size of uploaded data.
-
+\item[Meaning] Limits on the size of uploaded data.
 \item[Occurrence] optional
 
 \end{description}

--- a/TAPRegExt.tex
+++ b/TAPRegExt.tex
@@ -74,7 +74,15 @@ associated metadata is contained within the service resource description's
 
 TAPRegExt defines this capability element for TAP services.  In the context
 of registering TAP services, an important role filled by TAPRegExt is the
-communication of supported data models to the registry.
+communication of supported data models to the Registry.
+
+The specification comes with a non-normative example
+document\footnote{\auxiliaryurl{sample.xml}} showing this
+specification's  major features.  It also declares a separate capability
+for the VOSI capabilities endpoint.  The example is written as a
+response from a TAP service's capabilities endpoint.  When embedded in a
+VOResource record, the capability elements would be direct children of
+the \xmlel{vr:Resource} element.
 
 
 \subsection{TAPRegExt within the VO Architecture}
@@ -179,8 +187,7 @@ on a data model or a set of data models to work on all TAP services exposing
 tables instantiating the data model(s).
 
 In TAPRegExt, a data model is identified by its IVOA identifier
-\citep{2016ivoa.spec.0523D}.  The example document in Appendix~\ref{app:example}
-uses this to define support for both the ObsCore and RegTAP data models.
+\citep{2016ivoa.spec.0523D}.
 
 % GENERATED: !schemadoc TAPRegExt-v1.1.xsd DataModelType
 \begin{generated}
@@ -1562,183 +1569,6 @@ The schema accompanying this specific version is published alongside this
 document\footnote{\auxiliaryurl{TAPRegExt-v1.0.xsd}}.  The document at
 this URI is only intended for use in review or debugging.
 
-\section{Example Document}
-
-\label{app:example}
-
-This appendix contains an instance document as it should be
-delivered from the VOSI capability endpoint. When embedded in a
-VOResource record, the capability elements would be direct children of
-the \xmlel{vr:Resource} element.  The example file declares one custom
-extension to the async endpoint, a user defined function from the
-Catalogue of user defined functions, the common extension features from
-ADQL 2.1.  It also declares a separate capability for the VOSI
-capabilities endpoint.
-
-
-% GENERATED: make-sample.sh
-\begin{lstlisting}[basicstyle=\footnotesize,language=XML]
-<cap:capabilities
-	xmlns:cap="http://www.ivoa.net/xml/VOSICapabilities/v1.0"
-	xmlns:tr="http://www.ivoa.net/xml/TAPRegExt/v1.0"
-	xmlns:vg="http://www.ivoa.net/xml/VORegistry/v1.0"
-	xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0"
-	xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
-  <capability
-	standardID="ivo://ivoa.net/std/TAP"
-	xsi:type="tr:TableAccess">
-    <interface role="std" version="1.1"
-	xsi:type="vs:ParamHTTP">
-      <accessURL use="base">http://localhost:8080/tap</accessURL>
-    </interface>
-    <interface role="std" version="1.1"
-	xsi:type="tr:DALIInterface">
-      <accessURL use="base">http://localhost:8080/tap</accessURL>
-      <endpoint>
-        <name>sync</name>
-      </endpoint>
-      <endpoint>
-        <name>async</name>
-        <meta property="http://dc.g-vo.org/static/tap-plan">dachs</meta>
-      </endpoint>
-      <endpoint>
-        <name>tables</name>
-      </endpoint>
-      <endpoint>
-        <name>examples</name>
-      </endpoint>
-    </interface>
-    <dataModel ivo-id="ivo://org.gavo.dc/std/glots#tables-1.0">GloTS 1.0</dataModel>
-    <dataModel ivo-id="ivo://ivoa.net/std/ObsCore#core-1.1">Obscore-1.1</dataModel>
-    <language>
-      <name>ADQL</name>
-      <version ivo-id="ivo://ivoa.net/std/ADQL#v2.0">2.0</version>
-      <version ivo-id="ivo://ivoa.net/std/ADQL#v2.1">2.1</version>
-      <description>The Astronomical Data Query Language is...</description>
-      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-udf">
-        <feature>
-          <form>ivo_healpix_center(hpxOrder INTEGER, hpxIndex BIGINT) -&gt; POINT</form>
-          <description>returns a POINT corresponding to the center of the healpix with
-the given index at the given order.</description>
-        </feature>
-      </languageFeatures>
-      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adqlgeo">
-        <feature>
-          <form>BOX</form>
-        </feature>
-        <feature>
-          <form>POINT</form>
-        </feature>
-        <feature>
-          <form>CIRCLE</form>
-        </feature>
-        <feature>
-          <form>POLYGON</form>
-        </feature>
-        <feature>
-          <form>REGION</form>
-        </feature>
-        <feature>
-          <form>CENTROID</form>
-        </feature>
-        <feature>
-          <form>COORD1</form>
-        </feature>
-        <feature>
-          <form>COORD2</form>
-        </feature>
-        <feature>
-          <form>DISTANCE</form>
-        </feature>
-        <feature>
-          <form>CONTAINS</form>
-        </feature>
-        <feature>
-          <form>INTERSECTS</form>
-        </feature>
-        <feature>
-          <form>AREA</form>
-        </feature>
-      </languageFeatures>
-      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-string">
-        <feature>
-          <form>LOWER</form>
-        </feature>
-        <feature>
-          <form>ILIKE</form>
-        </feature>
-      </languageFeatures>
-      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-offset">
-        <feature>
-          <form>OFFSET</form>
-        </feature>
-      </languageFeatures>
-      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-type">
-        <feature>
-          <form>CAST</form>
-        </feature>
-      </languageFeatures>
-      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-unit">
-        <feature>
-          <form>IN_UNIT</form>
-        </feature>
-      </languageFeatures>
-      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-common-table">
-        <feature>
-          <form>WITH</form>
-        </feature>
-      </languageFeatures>
-      <languageFeatures type="ivo://org.gavo.dc/std/exts#extra-adql-keywords"/>
-      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-sets">
-        <feature>
-          <form>UNION</form>
-        </feature>
-        <feature>
-          <form>EXCEPT</form>
-        </feature>
-        <feature>
-          <form>INTERSECT</form>
-        </feature>
-      </languageFeatures>
-    </language>
-    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegEXT#output-votable-binary">
-      <mime>application/x-votable+xml</mime>
-      <alias>votable</alias>
-    </outputFormat>
-    <outputFormat>
-      <mime>text/csv</mime>
-    </outputFormat>
-    <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-inline"/>
-    <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-http"/>
-    <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-https"/>
-    <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-ftp"/>
-    <retentionPeriod>
-      <default>172800</default>
-    </retentionPeriod>
-    <executionDuration>
-      <default>7200</default>
-    </executionDuration>
-    <outputLimit>
-      <default unit="row">20000</default>
-      <hard unit="row">20000000</hard>
-    </outputLimit>
-    <uploadLimit>
-      <hard unit="byte">8000000</hard>
-    </uploadLimit>
-  </capability>
-  <capability
-	standardID="ivo://ivoa.net/std/VOSI#capabilities">
-    <interface role="std"
-	xsi:type="vs:ParamHTTP">
-      <accessURL use="full">http://localhost:8080/tap/capabilities</accessURL>
-    </interface>
-  </capability>
-</cap:capabilities>
-\end{lstlisting}
-
-% /GENERATED
-
 \section{Changes from Previous Versions}
 
 \label{changes}
@@ -1747,6 +1577,8 @@ the given index at the given order.</description>
 
 \begin{itemize}
 \item Adding tr:DALIInterface to the schema.
+\item Dropping the appendix with an example document.  Using a
+standalone, validated file and auxiliaryurl instead.
 \end{itemize}
 
 \subsection{Changes from WD-20110127}

--- a/make-sample.sh
+++ b/make-sample.sh
@@ -1,34 +1,21 @@
-#!/bin/sh
-# write a sample TAPRegExt record from the capabilities on
-# http://localhost:8080/tap to stdout; this, really, assumes a DaCHS running
-# there, and because of the validation, it also assumes a DaCHS is installed
-# locally.
+#!/bin/bash
+# write a sample TAPRegExt record from the capabilities on a DaCHS
+# server on localhost to stdout.  We validate the document against the schema
+# in this repo, so we need stilts as for make test.
 #
 # It also needs xmlstarlet.
 
-DEST=sample.xml
-
-function cleanup() {
-	rm -f $DEST.tmp.$$
-}
-trap cleanup EXIT
-
 curl -s http://localhost:8080/tap/capabilities \
-	| xmlstarlet ed -d "//feature[starts-with(form, 'ivo_apply_pm')]" \
-		-d "//languageFeatures[@type='ivo://ivoa.net/std/TAPRegExt#features-udf']/feature[not(starts-with(form, 'ivo_healpix_center'))]" \
-		-d "//languageFeatures[@type='ivo://org.gavo.dc/std/exts#extra-adql-keywords']/feature[not(starts-with(form, 'ivo_healpix_center'))]" \
-		-d "//outputFormat[not(mime='application/x-votable+xml' or mime='text/csv')]" \
+	| xmlstarlet ed \
 		-d "//capability[not(contains(@standardID, 'capabilities') or contains(@standardID, 'TAP'))]" \
-		-d "//dataModel[.='Registry 1.1']" \
-	| xmlstarlet fo -o -s 2 > $DEST.tmp.$$
+	| xmlstarlet fo -o -s 2
 
-dachs admin xsdValidate $DEST.tmp.$$ > /dev/null || exit 1
-echo '\begin{lstlisting}[basicstyle=\footnotesize,language=XML]'
-sed  -e 's/xmlns\|standardID\|xsi:type/\
-	&/g
-/xml-stylesheet/d
-s/xsi:schemaLocation="[^"]*"//
-s/\(Query Language is\)[^<]*/\1.../
-s/__system__\/tap\/run/tap/
-' $DEST.tmp.$$
-echo '\end{lstlisting}'
+exit 0
+STILTS=stilts
+SCHEMA_FILE=TAPRegExt-v1.1.xsd
+$STILTS xsdvalidate \
+		schemaloc="http://www.ivoa.net/xml/TAPRegExt/v1.0=$SCHEMA_FILE" \
+		schemaloc="http://www.ivoa.net/xml/VOSICapabilities/v1.0=https://www.ivoa.net/xml/VOSICapabilities/v1.0" \
+		schemaloc="http://www.ivoa.net/xml/VODataService/v1.1=https://www.ivoa.net/xml/VODataService/v1.1" \
+		doc=sample.xml
+

--- a/sample.xml
+++ b/sample.xml
@@ -1,23 +1,191 @@
-<cap:capabilities
-	xmlns:cap="http://www.ivoa.net/xml/VOSICapabilities/v1.0"
-	xmlns:tr="http://www.ivoa.net/xml/TAPRegExt/v1.0"
-	xmlns:vg="http://www.ivoa.net/xml/VORegistry/v1.0"
-	xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0"
-	xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
+<?xml-stylesheet href='/static/xsl/vosi.xsl' type='text/xsl'?>
+<cap:capabilities xmlns:cap="http://www.ivoa.net/xml/VOSICapabilities/v1.0" xmlns:dachs="http://docs.g-vo.org/schemata/DaCHS.xsd" xmlns:tr="http://www.ivoa.net/xml/TAPRegExt/v1.0" xmlns:vg="http://www.ivoa.net/xml/VORegistry/v1.0" xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0" xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOSICapabilities/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VOSICapabilities-v1.0.xsd http://docs.g-vo.org/schemata/DaCHS.xsd http://vo.ari.uni-heidelberg.de/docs/schemata/DaCHS.xsd http://www.ivoa.net/xml/TAPRegExt/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/TAPRegExt.xsd http://www.ivoa.net/xml/VORegistry/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VORegistry.xsd http://www.ivoa.net/xml/VOResource/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VOResource.xsd http://www.ivoa.net/xml/VODataService/v1.1 http://vo.ari.uni-heidelberg.de/docs/schemata/VODataService.xsd">
   <capability standardID="ivo://ivoa.net/std/TAP" xsi:type="tr:TableAccess">
     <interface role="std" version="1.1" xsi:type="vs:ParamHTTP">
-      <accessURL use="base">http://dc.zah.uni-heidelberg.de/tap</accessURL>
-      <mirrorURL>https://dc.zah.uni-heidelberg.de/tap</mirrorURL>
+      <accessURL use="full">http://victor:8080/tap</accessURL>
     </interface>
-    <dataModel ivo-id="ivo://ivoa.net/std/ObsCore#core-1.1">Obscore-1.1</dataModel>
-    <dataModel ivo-id="ivo://ivoa.net/std/RegTAP#1.1">Registry 1.1</dataModel>
+    <interface role="std" version="1.1" xsi:type="dachs:DALIInterface">
+      <accessURL use="full">http://victor:8080/tap</accessURL>
+      <endpoint>
+        <name>sync</name>
+      </endpoint>
+      <endpoint>
+        <name>async</name>
+        <meta property="http://dc.g-vo.org/static/tap-plan">dachs</meta>
+      </endpoint>
+      <endpoint>
+        <name>tables</name>
+      </endpoint>
+      <endpoint>
+        <name>examples</name>
+      </endpoint>
+    </interface>
+    <dataModel ivo-id="ivo://ivoa.net/std/regtap#1.2">Registry 1.2</dataModel>
+    <dataModel ivo-id="ivo://org.gavo.dc/std/glots#tables-1.0">GloTS 1.0</dataModel>
+    <dataModel ivo-id="ivo://ivoa.net/std/obscore#core-1.1">Obscore-1.1</dataModel>
+    <dataModel ivo-id="ivo://ivoa.net/std/TODO">Obsvis-1.0</dataModel>
     <language>
       <name>ADQL</name>
       <version ivo-id="ivo://ivoa.net/std/ADQL#v2.0">2.0</version>
       <version ivo-id="ivo://ivoa.net/std/ADQL#v2.1">2.1</version>
       <description>The Astronomical Data Query Language is the standard IVOA dialect of SQL; it contains a very general SELECT statement as well as some extensions for spherical geometry and higher mathematics.</description>
       <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-udf">
+        <feature>
+          <form>gavo_apply_pm(ra DOUBLE PRECISION, dec DOUBLE PRECISION, pmra DOUBLE PRECISION, pmde DOUBLE PRECISION, epdist DOUBLE PRECISION) -&gt; POINT</form>
+          <description>Returns a POINT (in the UNDEFINED reference frame) for the position
+an object at ra/dec with proper motion pmra/pmde has after epdist years.
+
+positions must be in degrees, PMs in should be in julian years (i.e., proper
+motions are expected in degrees/year).  pmra is assumed to contain
+cos(delta).
+
+This function goes through the tangential plane.  Since it does not have
+information on distance and radial velocity, it cannot reconstruct
+the true space motion, and hence its results will degrade over time.
+
+This function should not be used in new queries; use ivo_epoch_prop
+instead.</description>
+        </feature>
+        <feature>
+          <form>gavo_getauthority(ivoid TEXT) -&gt; TEXT</form>
+          <description>returns the authority part of an ivoid (or, more generally a URI).
+So, ivo://org.gavo.dc/foo/bar#baz becomes org.gavo.dc.
+
+The behaviour for anything that's not a full URI is undefined.</description>
+        </feature>
+        <feature>
+          <form>gavo_ipix(long REAL, lat REAL) -&gt; BIGINT</form>
+          <description>gavo_ipix returns the q3c ipix for a long/lat pair (it simply wraps
+the 13c_ang2ipix function).
+
+This is probably only relevant when you play tricks with indices or
+PPMXL ids.</description>
+        </feature>
+        <feature>
+          <form>gavo_match(pattern TEXT, string TEXT) -&gt; INTEGER</form>
+          <description>gavo_match returns 1 if the POSIX regular expression pattern
+matches anything in string, 0 otherwise.</description>
+        </feature>
+        <feature>
+          <form>gavo_mocintersect(moc1 MOC, moc2 MOC) -&gt; MOC</form>
+          <description>returns the intersection of two MOCs.</description>
+        </feature>
+        <feature>
+          <form>gavo_mocunion(moc1 MOC, moc2 MOC) -&gt; MOC</form>
+          <description>returns the union of two MOCs.</description>
+        </feature>
+        <feature>
+          <form>gavo_specconv(expr DOUBLE PRECISION, dest_unit TEXT) -&gt; DOUBLE PRECISION</form>
+          <description>returns the spectral value expr converted to dest_unit.
+
+expr has to be in either energy, wavelength, or frequency, and dest_unit
+must be a VOUnit giving another spectral unit (e.g., MHz, keV, nm, or
+Angstrom). This is intended to let users express spectral constraints
+in their preferred unit independently of the choice of unit in the
+database.  Examples::
+
+	gavo_specconv(obscore.em_min, "keV") &gt; 300
+	gavo_specconv(obscore.em_max, "MHz") &gt; 30
+	gavo_specconv(spectral_start, "Angstrom") &gt; 4000
+
+There is a variant of gavo_specconv accepting expr's unit in a third
+argument.</description>
+        </feature>
+        <feature>
+          <form>gavo_specconv(expr NUMERIC, expr_unit TEXT, dest_unit TEXT) -&gt; NUMERIC</form>
+          <description>returns expr assumed to be in expr_unit expressed in dest_unit.
+
+		This is a variant of the two-argument gavo_specconv for when
+		the unit of expr is not known to the ADQL translator, either because
+		it because it is a literal or because it does not look like
+		a spectral unit.  Examples::
+
+			gavo_specconv(656, 'nm', 'J') BETWEEN spectral_start AND spectral_end
+			gavo_specconv(arccos(phi)*incidence, 'Hz', 'eV')
+		
+		Clearly, overriding known units is likely to yield bad results;
+		the translator therefore warns if an existing unit is overridden
+		with a different unit.</description>
+        </feature>
+        <feature>
+          <form>gavo_vocmatch(vocname TEXT, term TEXT, matchagainst TEXT) -&gt; INTEGER</form>
+          <description>returns 1 if matchagainst is term or narrower in the IVOA vocabulary
+vocname, 0 otherwise.
+
+This is intended for semantic querying.  For instance,
+gavo_vocmatch('datalink/core', 'calibration', semantics) would be 1
+if semantics is any of calibration, bias, dark, or flat.
+
+For RDF-flavoured vocabularies (strict trees), term will expand to the
+entire branch rooted in term.  For SKOS-flavoured vocabularies (where
+narrower is not transitive), only directly narrower terms will be included.
+
+Both the term and the vocabulary name must be string literals (i.e.,
+constants).  matchagainst can be any string-valued expression.</description>
+        </feature>
+        <feature>
+          <form>ivo_epoch_prop(ra DOUBLE PRECISION, dec DOUBLE PRECISION, parallax DOUBLE PRECISION, pmra DOUBLE PRECISION, pmdec DOUBLE PRECISION, radial_velocity DOUBLE PRECISION, ref_epoch DOUBLE PRECISION, out_epoch DOUBLE PRECISION) -&gt; DOUBLE PRECISION[6]</form>
+          <description>Returns a 6-vector of (ra, dec, parallax, pmra, pmdec, rv)
+at out_epoch for these quantities at ref_epoch.
+
+Essentially, it will apply the proper motion under the assumption of
+linear motion.  Despite the name of the positional parameters, this is
+not restricted to equatorial systems, as long as positions and proper
+motions are expressed in the same reference frames.
+
+Units on input and output are degrees for ra and dec, mas for parallax,
+mas/yr for pmra and pmdec, and km/s for the radial velocity.
+
+ref_epoch and out_epoch are given in Julian years.
+
+parallax, pmra, pmdec, and radial_velocity may be None and will enter
+the computations as 0 then, except in the case of parallax, which
+will be some small value.  When abs(parallax) is smaller or equal
+to that small value, parallax and radial velocity will be NULL on
+output.
+
+In daily use, you probably want to use the ivo_epoch_prop_pos functions.</description>
+        </feature>
+        <feature>
+          <form>ivo_epoch_prop_pos(ra DOUBLE PRECISION, dec DOUBLE PRECISION, parallax DOUBLE PRECISION, pmra DOUBLE PRECISION, pmdec DOUBLE PRECISION, radial_velocity DOUBLE PRECISION, ref_epoch DOUBLE PRECISION, out_epoch DOUBLE PRECISION) -&gt; POINT</form>
+          <description>Returns a POINT giving the position at out_epoch for an object
+with the six parameters at ref_epoch.
+
+Essentially, it will apply the proper motion under the assumption of
+linear motion.  Despite the name of the positional parameters, this is
+not restricted to equatorial systems, as long as positions and proper
+motions are expressed in the same reference frames.
+
+Units on input are degrees for ra and dec, mas for parallax,
+mas/yr for pmra and pmdec, and km/s for the radial velocity.
+ref_epoch and out_epoch are given in Julian years.
+
+parallax, pmra, pmdec, and radial_velocity may be None and will enter
+the computations as 0 then, except in the case of parallax, which
+will be some small value.</description>
+        </feature>
+        <feature>
+          <form>ivo_epoch_prop_pos(ra DOUBLE PRECISION, dec DOUBLE PRECISION, pmra DOUBLE PRECISION, pmdec DOUBLE PRECISION, ref_epoch DOUBLE PRECISION, out_epoch DOUBLE PRECISION) -&gt; POINT</form>
+          <description>A variant of ivo_epoch_prop_pos that behave as if parallax
+		and radial_velocity were both passed as NULL.</description>
+        </feature>
+        <feature>
+          <form>ivo_geom_transform(from_sys TEXT, to_sys TEXT, geo GEOMETRY) -&gt; GEOMETRY</form>
+          <description>The function transforms ADQL geometries between various reference systems.
+geo can be a POINT, a CIRCLE, or a POLYGON, and the function will return a
+geometry of the same type.  In the current implementation, from_sys and
+to_sys must be literal strings (i.e., they cannot be computed through
+expressions or be taken from database columns).
+
+All transforms are just simple rotations, which is only a rough
+approximation to the actual relationships between reference systems
+(in particular between FK4 and ICRS-based ones).  Note that, in particular,
+the epoch is not changed (i.e., no proper motions are applied).
+
+We currently support the following reference frames: ICRS, FK5 (which
+is treated as ICRS), FK4 (for B1950. without epoch-dependent corrections),
+GALACTIC.  Reference frame names are case-sensitive.</description>
+        </feature>
         <feature>
           <form>ivo_hashlist_has(hashlist TEXT, item TEXT) -&gt; INTEGER</form>
           <description>The function takes two strings; the first is a list of words not
@@ -26,6 +194,104 @@ a word not containing the hash sign.  It returns 1 if, compared
 case-insensitively, the second argument is in the list of words coded in
 the first argument.  The behaviour in case the the second
 argument contains a hash sign is unspecified.</description>
+        </feature>
+        <feature>
+          <form>ivo_hasword(haystack TEXT, needle TEXT) -&gt; INTEGER</form>
+          <description>gavo_hasword returns 1 if needle shows up in haystack, 0 otherwise.  This
+is for "google-like"-searches in text-like fields.  In word, you can
+actually employ a fairly complex query language; see
+https://www.postgresql.org/docs/current/textsearch.html
+for details.</description>
+        </feature>
+        <feature>
+          <form>ivo_healpix_center(hpxOrder INTEGER, hpxIndex BIGINT) -&gt; POINT</form>
+          <description>returns a POINT corresponding to the center of the healpix with
+the given index at the given order.</description>
+        </feature>
+        <feature>
+          <form>ivo_healpix_index(order INTEGER, ra DOUBLE PRECISION, dec DOUBLE PRECISION) -&gt; BIGINT</form>
+          <description>Returns the index of the (nest) healpix with order containing the
+spherical point (ra, dec).
+
+An alternative, 2-argument form
+
+ivo_healpix_index(order INTEGER, p POINT) -&gt; BIGINT
+
+is also available.</description>
+        </feature>
+        <feature>
+          <form>ivo_histogram(val REAL, lower REAL, upper REAL, nbins INTEGER) -&gt; INTEGER[]</form>
+          <description>The aggregate function returns a histogram of val with nbins+2 elements.
+Assuming 0-based arrays, result[0] contains the number of underflows (i.e.,
+val&lt;lower), result[nbins+1] the number of overflows.  Elements 1..nbins
+are the counts in nbins bins of width (upper-lower)/nbins.  Clients
+will have to convert back to physical units using some external
+communication, there currently is no (meta-) data as lower and upper in
+the TAP response.</description>
+        </feature>
+        <feature>
+          <form>ivo_interval_has(val NUMERIC, iv INTERVAL) -&gt; INTEGER</form>
+          <description>The function returns 1 if the interval iv contains val, 0 otherwise.
+The lower limit is always included in iv, behaviour on the upper
+limit is column-specific.</description>
+        </feature>
+        <feature>
+          <form>ivo_interval_overlaps(l1 NUMERIC, h1 NUMERIC, l2 NUMERIC, h2 NUMERIC) -&gt; INTEGER</form>
+          <description>The function returns 1 if the interval [l1...h1] overlaps with
+the interval [l2...h2].  For the purposes of this function,
+the case l1=h2 or l2=h1 is treated as overlap.  The function
+returns 0 for non-overlapping intervals.</description>
+        </feature>
+        <feature>
+          <form>ivo_nocasematch(value TEXT, pattern TEXT) -&gt; INTEGER</form>
+          <description>ivo_nocasematch returns 1 if pattern matches value, 0 otherwise.
+pattern is defined as for the SQL LIKE operator, but the
+match is performed case-insensitively.  This function in effect
+provides a surrogate for the ILIKE SQL operator that is missing from
+ADQL.
+
+On this site, this is actually implemented using python's and SQL's
+LOWER, so for everything except ASCII, your mileage will vary.</description>
+        </feature>
+        <feature>
+          <form>ivo_normal_random(mu REAL, sigma REAL) -&gt; REAL</form>
+          <description>The function returns a random number drawn from a normal distribution
+with mean mu and width sigma.
+
+Implementation note: Right now, the Gaussian is approximated by
+summing up and scaling ten calls to random.  This, hence, is not
+very precise or fast.  It might work for some use cases, and we
+will provide a better implementation if this proves inadequate.</description>
+        </feature>
+        <feature>
+          <form>ivo_simbadpoint(identifier TEXT) -&gt; POINT</form>
+          <description>gavo_simbadpoint queries simbad for an identifier and returns the
+corresponding point.  Note that identifier can only be a literal,
+i.e., as simple string rather than a column name. This is because
+our database cannot query simbad, and we probably wouldn't want
+to fire off millions of simbad queries anyway; use simbad's own
+TAP service for this kind of application.</description>
+        </feature>
+        <feature>
+          <form>ivo_string_agg(expression TEXT, delimiter TEXT) -&gt; TEXT</form>
+          <description>An aggregate function returning all values of
+expression within a GROUP contcatenated with delimiter</description>
+        </feature>
+        <feature>
+          <form>ivo_to_jd(d TIMESTAMP) -&gt; DOUBLE PRECISION</form>
+          <description>The function converts a postgres timestamp to julian date.
+This is naive; no corrections for timezones, let alone time
+scales or the like are done; you can thus not expect this to be
+good to second-precision unless you are careful in the construction
+of the timestamp.</description>
+        </feature>
+        <feature>
+          <form>ivo_to_mjd(d TIMESTAMP) -&gt; DOUBLE PRECISION</form>
+          <description>The function converts a postgres timestamp to modified julian date.
+This is naive; no corrections for timezones, let alone time
+scales or the like are done; you can thus not expect this to be
+good to second-precision unless you are careful in the construction
+of the timestamp.</description>
         </feature>
       </languageFeatures>
       <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adqlgeo">
@@ -66,12 +332,20 @@ argument contains a hash sign is unspecified.</description>
           <form>AREA</form>
         </feature>
       </languageFeatures>
+      <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-conditional">
+        <feature>
+          <form>COALESCE</form>
+        </feature>
+      </languageFeatures>
       <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-string">
         <feature>
           <form>LOWER</form>
         </feature>
         <feature>
           <form>ILIKE</form>
+        </feature>
+        <feature>
+          <form>UPPER</form>
         </feature>
       </languageFeatures>
       <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-offset">
@@ -96,8 +370,20 @@ argument contains a hash sign is unspecified.</description>
       </languageFeatures>
       <languageFeatures type="ivo://org.gavo.dc/std/exts#extra-adql-keywords">
         <feature>
+          <form>TABLESAMPLE</form>
+          <description>Written after a table reference, TABLESAMPLE(10) will make the database only use 10% of the rows; these are `somewhat random' in that the system will use random blocks.  This should be good enough when just testing queries (and much better than using TOP n).</description>
+        </feature>
+        <feature>
           <form>MOC</form>
           <description>A geometry function creating MOCs.  It either takes a string argument with an ASCII MOC ('4/13 17-18 8/3002'), or an order and another geometry.</description>
+        </feature>
+        <feature>
+          <form>VECTORMATH</form>
+          <description>You can compute with vectors here. See https://wiki.ivoa.net/twiki/bin/view/IVOA/ADQLVectorMath for an overview of the functions and operators available.</description>
+        </feature>
+        <feature>
+          <form>CASE</form>
+          <description>The SQL92 CASE expression</description>
         </feature>
       </languageFeatures>
       <languageFeatures type="ivo://ivoa.net/std/TAPRegExt#features-adql-sets">
@@ -112,27 +398,75 @@ argument contains a hash sign is unspecified.</description>
         </feature>
       </languageFeatures>
     </language>
-    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegEXT#output-votable-binary">
-      <mime>application/x-votable+xml</mime>
-      <alias>votable</alias>
+    <outputFormat>
+      <mime>text/tab-separated-values</mime>
+      <alias>tsv</alias>
     </outputFormat>
-    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary">
-      <mime>text/xml</mime>
-    </outputFormat>
-    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary2">
-      <mime>application/x-votable+xml;serialization=binary2</mime>
-      <alias>votable/b2</alias>
-    </outputFormat>
-    <outputFormat ivo-id="http://dc.g-vo.org/output-vodml">
-      <mime>application/x-votable+xml;version=1.4</mime>
-      <alias>vodml</alias>
-    </outputFormat>
-    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegEXT#output-votable-td">
-      <mime>application/x-votable+xml;serialization=tabledata</mime>
-      <alias>votable/td</alias>
+    <outputFormat>
+      <mime>text/plain</mime>
+      <alias>txt</alias>
     </outputFormat>
     <outputFormat>
       <mime>text/csv</mime>
+      <alias>csv_bare</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>text/csv;header=present</mime>
+      <alias>csv</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>application/json</mime>
+      <alias>json</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>application/geo+json</mime>
+      <alias>geojson</alias>
+    </outputFormat>
+    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary">
+      <mime>application/x-votable+xml</mime>
+      <alias>votable</alias>
+    </outputFormat>
+    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary2">
+      <mime>application/x-votable+xml;serialization=BINARY2</mime>
+      <alias>votable/b2</alias>
+      <alias>votableb2</alias>
+    </outputFormat>
+    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-td">
+      <mime>application/x-votable+xml;serialization=TABLEDATA</mime>
+      <alias>text/xml</alias>
+      <alias>votable/td</alias>
+      <alias>votabletd</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>application/x-votable+xml;serialization=TABLEDATA;version=1.1</mime>
+      <alias>text/xml</alias>
+      <alias>votabletd1.1</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>application/x-votable+xml;version=1.1</mime>
+      <alias>text/xml</alias>
+      <alias>votable1.1</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>application/x-votable+xml;serialization=TABLEDATA;version=1.2</mime>
+      <alias>text/xml</alias>
+      <alias>votabletd1.2</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>application/x-votable+xml;serialization=TABLEDATA;version=1.6</mime>
+      <alias>vodml</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>application/x-votable+xml;version=1.6</mime>
+      <alias>vodmlb</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>text/html</mime>
+      <alias>html</alias>
+    </outputFormat>
+    <outputFormat>
+      <mime>application/fits</mime>
+      <alias>fits</alias>
     </outputFormat>
     <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-inline"/>
     <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-http"/>
@@ -146,28 +480,15 @@ argument contains a hash sign is unspecified.</description>
     </executionDuration>
     <outputLimit>
       <default unit="row">20000</default>
-      <hard unit="row">16000000</hard>
+      <hard unit="row">20000000</hard>
     </outputLimit>
     <uploadLimit>
-      <hard unit="byte">100000000</hard>
+      <hard unit="byte">80000000</hard>
     </uploadLimit>
   </capability>
   <capability standardID="ivo://ivoa.net/std/VOSI#capabilities">
     <interface role="std" xsi:type="vs:ParamHTTP">
-      <accessURL use="full">http://dc.zah.uni-heidelberg.de/capabilities</accessURL>
-      <mirrorURL>https://dc.zah.uni-heidelberg.de/capabilities</mirrorURL>
-    </interface>
-  </capability>
-  <capability standardID="ivo://ivoa.net/std/VOSI#tables">
-    <interface role="std" xsi:type="vs:ParamHTTP">
-      <accessURL use="full">http://dc.zah.uni-heidelberg.de/tableMetadata</accessURL>
-      <mirrorURL>https://dc.zah.uni-heidelberg.de/tableMetadata</mirrorURL>
-    </interface>
-  </capability>
-  <capability standardID="ivo://ivoa.net/std/DALI#examples">
-    <interface xsi:type="vr:WebBrowser">
-      <accessURL use="full">http://dc.zah.uni-heidelberg.de/examples</accessURL>
-      <mirrorURL>https://dc.zah.uni-heidelberg.de/examples</mirrorURL>
+      <accessURL use="full">http://victor:8080/__system__/tap/run/capabilities</accessURL>
     </interface>
   </capability>
 </cap:capabilities>

--- a/samplegroom.sed
+++ b/samplegroom.sed
@@ -1,6 +1,0 @@
-s/xmlns/\
-	&/g
-s/xsi:schemaLocation="[^"]*"//
-s/__system__\/tap\/run\///
-/<?xml/d
-/Registry STC/d

--- a/test-assertions.sh
+++ b/test-assertions.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+SCHEMA=TAPRegExt-v1.1.xsd
+
+die() {
+	echo $*
+	exit 1
+}
+
+
+assert_schema_version_for_rec() {
+	# make sure the schema version has no tags if this is a REC
+	if xmlstarlet sel -T -t -m "xs:schema" -v "@version"  $SCHEMA \
+		| grep "^[0-9]\.[0-9]$" > /dev/null ; then
+		: # all is fine
+	else
+		die "$SCHEMA version has tags (inappropriate for a REC release)"
+	fi
+}
+
+if grep "ivoaDoctype}{REC}" ivoatexmeta.tex > /dev/null; then
+	assert_schema_version_for_rec
+fi


### PR DESCRIPTION
This PR does three things:

(a) it updates the CI

(b) it adds tests

(c) it removes the formatted sample file from the PDF, instead linking to an auxiliary, standalong file.

The latter thing may be considered a non-housekeeping thing; but then wasting all these pages for something folks will want to have machine-readable anyway does seem a bad idea, and the content is largely unmodified; we just don't throw out the majority of UDFs any more.

(This material has been part of PR #8 so far, but it doesn't really belong to it.  I'll rebase PR #8 on this once it's merged, which will make the diff look a lot less cluttered)